### PR TITLE
Rely on PATH to figure out binary location

### DIFF
--- a/terraform/modules/attached_ebs/cloudinit/ebs_bootstrap_unit
+++ b/terraform/modules/attached_ebs/cloudinit/ebs_bootstrap_unit
@@ -9,8 +9,8 @@ ${depends}
 
 [Service]
 Type=oneshot
-ExecStartPre=/usr/bin/curl -C - -L -o /tmp/ebs-bootstrap ${ebs_bootstrap_binary_url}
-ExecStartPre=/usr/bin/chmod +x /tmp/ebs-bootstrap
+ExecStartPre=curl -C - -L -o /tmp/ebs-bootstrap ${ebs_bootstrap_binary_url}
+ExecStartPre=chmod +x /tmp/ebs-bootstrap
 RemainAfterExit=true
 ExecStart=/tmp/ebs-bootstrap \
     -ebs-volume-name=${ebs_volume_name} \


### PR DESCRIPTION
Unfortunately, we were relying on a symlink'd /usr/bin/chmod that has apparently been removed, however this seems like a better approach as:

```If the command is not a full (absolute) path, it will be resolved to a full path using a fixed search path determined at compilation time. Searched directories include /usr/local/bin/, /usr/bin/, /bin/ on systems using split /usr/bin/ and /bin/ directories, and their sbin/ counterparts on systems using split bin/ and sbin/. It is thus safe to use just the executable name in case of executables located in any of the "standard" directories, and an absolute path must be used in other cases. Using an absolute path is recommended to avoid ambiguity. Hint: this search path may be queried using systemd-path search-binaries-default.```

From https://www.freedesktop.org/software/systemd/man/systemd.service.html