### PR TITLE
Return to static paths

### DIFF
--- a/terraform/modules/attached_ebs/cloudinit/ebs_bootstrap_unit
+++ b/terraform/modules/attached_ebs/cloudinit/ebs_bootstrap_unit
@@ -9,8 +9,8 @@ ${depends}
 
 [Service]
 Type=oneshot
-ExecStartPre=curl -C - -L -o /tmp/ebs-bootstrap ${ebs_bootstrap_binary_url}
-ExecStartPre=chmod +x /tmp/ebs-bootstrap
+ExecStartPre=/usr/bin/curl -C - -L -o /tmp/ebs-bootstrap ${ebs_bootstrap_binary_url}
+ExecStartPre=/bin/chmod +x /tmp/ebs-bootstrap
 RemainAfterExit=true
 ExecStart=/tmp/ebs-bootstrap \
     -ebs-volume-name=${ebs_volume_name} \


### PR DESCRIPTION
Unfortunately, #1 just so happens to not work with the particular systemd version used by Ubuntu, our main target. Revert to using static paths and this time `/bin/chmod` over the now-no-longer-existent `/usr/bin/chmod`.